### PR TITLE
Fix non-ascii module names

### DIFF
--- a/pyinstxtractor_ng.py
+++ b/pyinstxtractor_ng.py
@@ -443,9 +443,12 @@ class PyInstArchive:
 
                 try:
                     # for Python > 3.3 some keys are bytes object some are str object
-                    fileName = fileName.decode("utf-8")
+                    fileName = fileName.__str__()
                 except:
-                    pass
+                    try:
+                        fileName = fileName.decode("utf-8")
+                    except:
+                        pass
 
                 # Prevent writing outside dirName
                 fileName = fileName.replace("..", "__").replace(".", os.path.sep)


### PR DESCRIPTION
Fixed an improper call to xdis.cross_types.UnicodeForPython3 that caused abnormal export filenames for non-ASCII module names.
<img width="1165" height="589" alt="image" src="https://github.com/user-attachments/assets/0fc6918c-6f7a-4ce0-b35d-39dff2972e63" />
<img width="647" height="432" alt="image" src="https://github.com/user-attachments/assets/783cda59-5d58-4476-b339-9d842c498871" />
